### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.suo
+*.exe
+*.ilk
+*.pdb
+*.sdf
+*.sln
+*.log
+*.obj
+*.o
+*.tlog
+*.lastbuildstate
+*.idb
+*.vcxproj
+*.filters


### PR DESCRIPTION
git 저장소에서 필요없는 파일을 무시하는 방법
1. 저장소 최상위에 ".gitignore" 파일생성
2. ".gitignore" 파일에 필요없는 파일 서술